### PR TITLE
add pre-allocation for each cpu grad and overlap CPU/CUDA step

### DIFF
--- a/megatron/core/optimizer/cpu_offloading/benchmark_io.py
+++ b/megatron/core/optimizer/cpu_offloading/benchmark_io.py
@@ -1,0 +1,34 @@
+# This file tries to benchmark non-blocking copy/to ops on pageable/pinned tensors.
+import torch
+from torch.utils.benchmark import Timer
+
+@torch.inference_mode()
+def timer(cmd):
+    median = (
+        Timer(cmd, globals=globals())
+        .adaptive_autorange(min_run_time=1.0, max_run_time=20.0)
+        .median
+        * 1000
+    )
+    print(f"{cmd}: {median: 4.4f} ms")
+    return median
+
+cpu_datas = []
+
+# A tensor in pageable memory
+pageable_tensor = torch.randn(1_000_000)
+
+# A tensor in page-locked (pinned) memory
+pinned_tensor = torch.randn(1_000_000, pin_memory=True)
+
+# A CUDA tensor
+cuda_tensor = torch.randn(1_000_000, device='cuda')
+
+# Runtimes:
+pageable_to_device = timer("pageable_tensor.to('cuda:0')")
+pinned_to_device = timer("pinned_tensor.to('cuda:0')")
+device_copy_to_pageable = timer("pageable_tensor.data.copy_(cuda_tensor)")
+device_copy_to_pinned = timer("pinned_tensor.data.copy_(cuda_tensor)")
+device_to_host = timer("cuda_tensor.cpu()")
+device_to_host_add_list = timer("cpu_datas.append(cuda_tensor.cpu())")
+

--- a/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
+++ b/megatron/core/optimizer/cpu_offloading/hybrid_optimizer.py
@@ -20,6 +20,8 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         self.cpu_optimizer = cpu_optimizer_cls(self.cpu_params, **kwargs)
         self.gpu_optimizer = gpu_optimizer_cls(self.gpu_params, **kwargs)
         self.cpu_copy_map_grad: Dict[torch.Tensor, torch.Tensor] = defaultdict(torch.Tensor)
+        self._data_stream = torch.cuda.Stream()
+        self._step_stream = torch.cuda.Stream()
 
         self.register_grad_cpu_copy_hook()
         self.register_param_copy_back_gpu_hook()
@@ -34,8 +36,11 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
                             dtype=gpu_param.grad.dtype,
                             pin_memory=self.pin_cpu_grads
                         )
-                    self.cpu_copy_map_grad[cpu_copy].data.copy_(gpu_param.grad, non_blocking=True)
-                    cpu_copy.grad = self.cpu_copy_map_grad[cpu_copy]
+                self._data_stream.wait_stream(torch.cuda.default_stream())
+                with torch.cuda.stream(self._data_stream):
+                    for gpu_param, cpu_copy in self.gpu_params_map_cpu_copy.items():
+                        self.cpu_copy_map_grad[cpu_copy].data.copy_(gpu_param.grad, non_blocking=True)
+                        cpu_copy.grad = self.cpu_copy_map_grad[cpu_copy]
             return grad_cpu_copy_hook
 
         self.register_step_pre_hook(grad_cpu_copy_hook_closure())
@@ -43,8 +48,12 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
     def register_param_copy_back_gpu_hook(self):
         def param_copy_back_gpu_hook_closure():
             def param_copy_back_gpu_hook(optimizer, args, kwargs):
-                for cpu_copy, gpu_param in self.cpu_copys_map_gpu_param.items():
-                    gpu_param.data.copy_(cpu_copy.data)
+                self._data_stream.wait_stream(torch.cuda.default_stream())
+                with torch.cuda.stream(self._data_stream):      
+                    for cpu_copy, gpu_param in self.cpu_copys_map_gpu_param.items():
+                        gpu_param.data.copy_(cpu_copy.data, non_blocking=True)
+                # NOTE: ensure all H2D/D2H Transfer and update operations finish
+                torch.cuda.synchronize()
 
             return param_copy_back_gpu_hook
 
@@ -84,8 +93,11 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         return self.cpu_optimizer.param_groups + self.gpu_optimizer.param_groups
 
     def step(self, closure=None):
+        self._step_stream.wait_stream(torch.cuda.default_stream())
+        with torch.cuda.stream(self._step_stream):
+            self.gpu_optimizer.step(closure)
+        self._data_stream.synchronize()
         self.cpu_optimizer.step(closure)
-        self.gpu_optimizer.step(closure)
 
     def _split_parameters_updated_on_the_cpu_and_gpu(self):
         total_params_numel = sum([p.numel() for p in self.params])
@@ -99,7 +111,7 @@ class HybridDeviceOptimizer(torch.optim.Optimizer):
         for param in self.params:
             if offloaded_params_numel < offload_threshold:
                 assert param.is_cuda
-                param_cpu_copy = param.detach().cpu()
+                param_cpu_copy = param.detach().cpu().pin_memory()
                 param_cpu_copy.requires_grad = True
                 gpu_params_map_cpu_copy[param] = param_cpu_copy
                 cpu_copys_map_gpu_param[param_cpu_copy] = param


### PR DESCRIPTION
The benchmark results on V100/A100/H20:

![image](https://github.com/user-attachments/assets/0b0cd297-1f86-4895-a190-6e495c80f945)

As expected, blocked data transfer between pre-allocated pin-memory host tensor and CUDA tensor is faster than others. However, I cannot point out why `Tensor.to` is slightly faster than copy from/to pageable host Tensor.